### PR TITLE
Integrate Caffe based changes for MCW Version 1.3 of pruning tool

### DIFF
--- a/include/caffe/layers/squeeze_conv_layer.hpp
+++ b/include/caffe/layers/squeeze_conv_layer.hpp
@@ -81,7 +81,7 @@ class SqueezeConvolutionLayer : public BaseConvolutionLayer<Dtype> {
   virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
   virtual void AggregateParams(const int, const Dtype* , const Dtype* ,
-    Dtype* , Dtype* , unsigned int* );
+    unsigned int* );
   virtual void CalculateMask(const int, const Dtype* , Dtype* ,
     Dtype , Dtype , Dtype );
   

--- a/include/caffe/layers/squeeze_deconv_layer.hpp
+++ b/include/caffe/layers/squeeze_deconv_layer.hpp
@@ -48,7 +48,7 @@ class SqueezeDeconvolutionLayer : public BaseConvolutionLayer<Dtype> {
   virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
   virtual void AggregateParams(const int, const Dtype* , const Dtype* ,
-    Dtype* , Dtype* , unsigned int* );
+    unsigned int* );
   virtual void CalculateMask(const int, const Dtype* , Dtype* ,
     Dtype , Dtype , Dtype );
 

--- a/include/caffe/layers/squeeze_inner_product_layer.hpp
+++ b/include/caffe/layers/squeeze_inner_product_layer.hpp
@@ -24,7 +24,7 @@ class SqueezeInnerProductLayer : public Layer<Dtype> {
   virtual inline int ExactNumBottomBlobs() const { return 1; }
   virtual inline int ExactNumTopBlobs() const { return 1; }
   virtual void AggregateParams(const int, const Dtype* , const Dtype* ,
-    Dtype* , Dtype* , unsigned int* );
+    unsigned int* );
   virtual void CalculateMask(const int, const Dtype* , Dtype* ,
     Dtype , Dtype , Dtype );
 

--- a/src/caffe/layers/squeeze_conv_layer.cpp
+++ b/src/caffe/layers/squeeze_conv_layer.cpp
@@ -17,7 +17,8 @@ void SqueezeConvolutionLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bott
   SqueezeConvolutionParameter sqconv_param = this->layer_param_.squeeze_convolution_param();
 
   if(this->blobs_.size()==2 && (this->bias_term_)){
-    this->blobs_.resize(4);
+    //Resized the blobs to store WeightMask,BiasMask, mu and std values
+    this->blobs_.resize(5);
 
     // Intialize and fill the weightmask & biasmask
     this->blobs_[2].reset(new Blob<Dtype>(this->blobs_[0]->shape()));
@@ -28,14 +29,17 @@ void SqueezeConvolutionLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bott
     shared_ptr<Filler<Dtype> > bias_mask_filler(GetFiller<Dtype>(
         sqconv_param.bias_mask_filler()));
     bias_mask_filler->Fill(this->blobs_[3].get());
+    //Blob is set to the shape (1,1,1,2) to store mu and std values alone
+    this->blobs_[4].reset(new Blob<Dtype>(1,1,1,2));
   }
   else if(this->blobs_.size()==1 && (!this->bias_term_)){
-    this->blobs_.resize(2);
+    this->blobs_.resize(3);
     // Intialize and fill the weightmask
     this->blobs_[1].reset(new Blob<Dtype>(this->blobs_[0]->shape()));
     shared_ptr<Filler<Dtype> > weight_mask_filler(GetFiller<Dtype>(
         sqconv_param.weight_mask_filler()));
     weight_mask_filler->Fill(this->blobs_[1].get());
+    this->blobs_[2].reset(new Blob<Dtype>(1,1,1,2));
   }
 
   // Intializing the tmp tensor
@@ -72,7 +76,7 @@ void SqueezeConvolutionLayer<Dtype>::compute_output_shape() {
 
 template <typename Dtype>
 void SqueezeConvolutionLayer<Dtype>::AggregateParams(const int n, const Dtype* wb, const Dtype* mask,
-    Dtype* mu, Dtype* std, unsigned int *count) {
+    unsigned int *count) {
   for (unsigned int k = 0;k < n; ++k) {
     this->mu  += fabs(mask[k] * wb[k]);
     this->std += mask[k] * wb[k] * wb[k];
@@ -101,6 +105,7 @@ void SqueezeConvolutionLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bot
   const Dtype* bias = NULL;
   Dtype* biasMask = NULL;
   Dtype* biasTmp = NULL;
+  Dtype* prune_threshold_params = NULL;
   int maskcount = 0;
   if (this->bias_term_) {
     weight = this->blobs_[0]->mutable_cpu_data();
@@ -108,12 +113,14 @@ void SqueezeConvolutionLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bot
     weightTmp = this->weight_tmp_.mutable_cpu_data();
     bias = this->blobs_[1]->mutable_cpu_data();
     biasMask = this->blobs_[3]->mutable_cpu_data();
+    prune_threshold_params = this->blobs_[4]->mutable_cpu_data(); // To store mu and std values
     biasTmp = this->bias_tmp_.mutable_cpu_data();
     maskcount = this->blobs_[2]->count();
   }
   else {
     weight = this->blobs_[0]->mutable_cpu_data();
     weightMask = this->blobs_[1]->mutable_cpu_data();
+    prune_threshold_params = this->blobs_[2]->mutable_cpu_data();
     weightTmp = this->weight_tmp_.mutable_cpu_data();
     maskcount = this->blobs_[1]->count();
   }
@@ -129,25 +136,27 @@ void SqueezeConvolutionLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bot
         weightMask[l] = abs(round(weightMask[l]));
       }
     }
-    // Calculate the mean and standard deviation of learnable parameters 
+    // Calculate the mean and standard deviation of learnable parameters
     if ((this->std == 0 && this->iter_ == 0) || this->iter_== 40 || this->iter_== 80 || this->iter_== 120 || this->iter_== 160) {
       unsigned int ncount = 0;
-      AggregateParams(this->blobs_[0]->count(), weight, weightMask, &mu, &std, &ncount);
+      AggregateParams(this->blobs_[0]->count(), weight, weightMask, &ncount);
       if (this->bias_term_) {
-        AggregateParams(this->blobs_[1]->count(), bias, biasMask, &mu, &std, &ncount);
+        AggregateParams(this->blobs_[1]->count(), bias, biasMask, &ncount);
       }
-      this->mu /= ncount; this->std -= ncount * mu * mu;
-      this->std /= ncount; this->std = sqrt(std);
+      this->mu /= ncount; this->std -= ncount * this->mu * this->mu;
+      this->std /= ncount; this->std = sqrt(this->std);
+      // Storing mu and std values into the blob
+      prune_threshold_params[0] = this->mu;
+      prune_threshold_params[1] = this->std;
     }
-
     // No pruning/splicing during Retraining
     // Calculate the weight mask and bias mask with probability
     Dtype r = static_cast<Dtype>(rand())/static_cast<Dtype>(RAND_MAX);
     if (pow(1 + (this->gamma) * (this->iter_), -(this->power)) > r && (this->iter_) < (this->iter_stop_)) {
-      CalculateMask(this->blobs_[0]->count(), weight, weightMask, this->mu, this->std, this->crate);  
+      CalculateMask(this->blobs_[0]->count(), weight, weightMask, prune_threshold_params[0], prune_threshold_params[1], this->crate);
       if (this->bias_term_) {
-        CalculateMask(this->blobs_[1]->count(), bias, biasMask, this->mu, this->std, this->crate);
-      } 
+        CalculateMask(this->blobs_[1]->count(), bias, biasMask, prune_threshold_params[0], prune_threshold_params[1], this->crate);
+      }
     }
     // Dynamic Splicing
     // Unprune the pruned weights based on the splicing ratio
@@ -168,11 +177,13 @@ void SqueezeConvolutionLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bot
         int start_index = 0;
         int end_index = 0;
         for (unsigned int k = 0; k < zero_count; ++k) {
-          if (prune_node[k].first > (0.25 * (this->mu + this->std))) {
+          if (prune_node[k].first > (0.25 * (prune_threshold_params[0] + prune_threshold_params[1]))) {
             start_index = k;
             break;
           }
         }
+        if(start_index == 0)
+          start_index = zero_count - to_bespliced; //Update start index
         end_index = start_index + to_bespliced;
         if (end_index > zero_count) {
           start_index = start_index - (end_index - zero_count);
@@ -196,7 +207,7 @@ void SqueezeConvolutionLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bot
     }
   }
 
-  // Forward calculation with (masked) weight and bias 
+  // Forward calculation with (masked) weight and bias
   for (int i = 0; i < bottom.size(); ++i) {
     const Dtype* bottom_data = bottom[i]->cpu_data();
     Dtype* top_data = top[i]->mutable_cpu_data();
@@ -213,7 +224,7 @@ void SqueezeConvolutionLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bot
 template <typename Dtype>
 void SqueezeConvolutionLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
-  const Dtype* weightTmp = this->weight_tmp_.cpu_data();  
+  const Dtype* weightTmp = this->weight_tmp_.cpu_data();
   const Dtype* weightMask = NULL;
   if(this->bias_term_)
     weightMask = this->blobs_[2]->cpu_data();

--- a/src/caffe/layers/squeeze_inner_product_layer.cpp
+++ b/src/caffe/layers/squeeze_inner_product_layer.cpp
@@ -52,7 +52,8 @@ void SqueezeInnerProductLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bot
   SqueezeInnerProductParameter squeeze_inner_param = this->layer_param_.squeeze_inner_product_param();
 
   if(this->blobs_.size() == 2 && (this->bias_term_)){
-    this->blobs_.resize(4);
+    //Resized the blobs to store WeightMask,BiasMask, mu and std values
+    this->blobs_.resize(5);
     // Intialize and fill the weightmask & biasmask
     this->blobs_[2].reset(new Blob<Dtype>(this->blobs_[0]->shape()));
     shared_ptr<Filler<Dtype> > weight_mask_filler(GetFiller<Dtype>(
@@ -62,14 +63,17 @@ void SqueezeInnerProductLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bot
     shared_ptr<Filler<Dtype> > bias_mask_filler(GetFiller<Dtype>(
         squeeze_inner_param.bias_mask_filler()));
     bias_mask_filler->Fill(this->blobs_[3].get());
-  }  
+    //Blob is set to the shape (1,1,1,2) to store mu and std values alone
+    this->blobs_[4].reset(new Blob<Dtype>(1,1,1,2));
+  }
   else if(this->blobs_.size()==1 && (!this->bias_term_)){
-    this->blobs_.resize(2);
+    this->blobs_.resize(3);
     // Intialize and fill the weightmask
     this->blobs_[1].reset(new Blob<Dtype>(this->blobs_[0]->shape()));
     shared_ptr<Filler<Dtype> > weight_mask_filler(GetFiller<Dtype>(
         squeeze_inner_param.weight_mask_filler()));
     weight_mask_filler->Fill(this->blobs_[1].get());
+    this->blobs_[2].reset(new Blob<Dtype>(1,1,1,2));
   }
   // Intialize the tmp tensor 
   this->weight_tmp_.Reshape(this->blobs_[0]->shape());
@@ -114,7 +118,7 @@ void SqueezeInnerProductLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom
 
 template <typename Dtype>
 void SqueezeInnerProductLayer<Dtype>::AggregateParams(const int n, const Dtype* wb, const Dtype* mask,
-    Dtype* mu, Dtype* std, unsigned int *count) {
+    unsigned int *count) {
 
   for (unsigned int k = 0;k < n; ++k) {
     this->mu  += fabs(mask[k] * wb[k]);
@@ -146,6 +150,7 @@ void SqueezeInnerProductLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bo
   const Dtype* bias = NULL;
   Dtype* biasMask = NULL;
   Dtype* biasTmp = NULL;
+  Dtype* prune_threshold_params = NULL;
   int maskcount = 0;
   if (this->bias_term_) {
     weight = this->blobs_[0]->mutable_cpu_data();
@@ -153,12 +158,14 @@ void SqueezeInnerProductLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bo
     weightTmp = this->weight_tmp_.mutable_cpu_data();
     bias = this->blobs_[1]->mutable_cpu_data();
     biasMask = this->blobs_[3]->mutable_cpu_data();
+    prune_threshold_params = this->blobs_[4]->mutable_cpu_data(); // To store mu and std values
     biasTmp = this->bias_tmp_.mutable_cpu_data();
     maskcount = this->blobs_[2]->count();
   }
   else {
     weight = this->blobs_[0]->mutable_cpu_data();
     weightMask = this->blobs_[1]->mutable_cpu_data();
+    prune_threshold_params = this->blobs_[2]->mutable_cpu_data();
     weightTmp = this->weight_tmp_.mutable_cpu_data();
     maskcount = this->blobs_[1]->count();
   }
@@ -175,21 +182,21 @@ void SqueezeInnerProductLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bo
     // Calculate the mean and standard deviation of learnable parameters 
     if (this->std==0 && this->iter_==0) {
       unsigned int ncount = 0;
-      AggregateParams(this->blobs_[0]->count(), weight, weightMask, &mu, &std, &ncount);
+      AggregateParams(this->blobs_[0]->count(), weight, weightMask, &ncount);
       if (this->bias_term_) {
-        AggregateParams(this->blobs_[1]->count(), bias, biasMask, &mu, &std, &ncount);
+        AggregateParams(this->blobs_[1]->count(), bias, biasMask, &ncount);
       }
-      this->mu /= ncount; this->std -= ncount*mu*mu;
-      this->std /= ncount; this->std = sqrt(std);
+      // Storing mu and std values into the blob
+      prune_threshold_params[0] = this->mu;
+      prune_threshold_params[1] = this->std;
     }
-
     // No pruning done during Retraining
     // Perform pruning or Splicing
     Dtype r = static_cast<Dtype>(rand())/static_cast<Dtype>(RAND_MAX);
     if (pow( 1 + (this->gamma) * (this->iter_), -(this->power)) > r && (this->iter_) < (this->iter_stop_)) {
-      CalculateMask(this->blobs_[0]->count(), weight, weightMask, this->mu, this->std, this->crate);
+      CalculateMask(this->blobs_[0]->count(), weight, weightMask, prune_threshold_params[0],prune_threshold_params[1], this->crate);
       if (this->bias_term_) {
-        CalculateMask(this->blobs_[1]->count(), bias, biasMask, this->mu, this->std, this->crate);
+        CalculateMask(this->blobs_[1]->count(), bias, biasMask, prune_threshold_params[0], prune_threshold_params[1], this->crate);
       }
     }
     // Dynamic Splicing
@@ -211,11 +218,13 @@ void SqueezeInnerProductLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bo
         int start_index = 0;
         int end_index = 0;
         for (unsigned int k = 0; k < zero_count; ++k) {
-          if (prune_node[k].first > (0.25 * (this->mu + this->std))) {
+          if (prune_node[k].first > (0.25 * (prune_threshold_params[0] + prune_threshold_params[1]))) {
             start_index = k;
             break;
           }
         }
+        if(start_index == 0)
+          start_index = zero_count - to_bespliced; //Update start index
         end_index = start_index + to_bespliced;
         if (end_index > zero_count) {
           start_index = start_index - (end_index - zero_count);


### PR DESCRIPTION
 @vera121 We have integrated MCW version 1.3 Caffe patch into the development branch of Synopsys-Caffe. This commit includes enhanced dynamic-splicing logic, logic to resume training using a snapshot file (.solverstate) for pruning experiments and also removed unused function.